### PR TITLE
BT LED no longer hardcoded

### DIFF
--- a/keyboards/annepro2/annepro2.c
+++ b/keyboards/annepro2/annepro2.c
@@ -128,23 +128,22 @@ bool OVERRIDE process_record_kb(uint16_t keycode, keyrecord_t *record) {
         switch (keycode) {
             case KC_AP2_BT1:
                 annepro2_ble_broadcast(0);
-                /* FIXME: This hardcodes col/row position */
-                annepro2LedBlink(0, 1, blue, 8, 50);
+                annepro2LedBlink(record->event.key.row, record->event.key.col, blue, 8, 50);
                 return false;
 
             case KC_AP2_BT2:
                 annepro2_ble_broadcast(1);
-                annepro2LedBlink(0, 2, blue, 8, 50);
+                annepro2LedBlink(record->event.key.row, record->event.key.col, blue, 8, 50);
                 return false;
 
             case KC_AP2_BT3:
                 annepro2_ble_broadcast(2);
-                annepro2LedBlink(0, 3, blue, 8, 50);
+                annepro2LedBlink(record->event.key.row, record->event.key.col, blue, 8, 50);
                 return false;
 
             case KC_AP2_BT4:
                 annepro2_ble_broadcast(3);
-                annepro2LedBlink(0, 4, blue, 8, 50);
+                annepro2LedBlink(record->event.key.row, record->event.key.col, blue, 8, 50);
                 return false;
 
             case KC_AP2_USB:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
BT LED is no longer hardcoded and will blink to the corresponding key it is mapped to.
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
